### PR TITLE
fix(e2e): update accessibility tests for Tailwind v4 and browser compatibility

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -65,27 +65,23 @@ test.describe('Accessibility', () => {
 
     const skipLink = page.locator('a[href="#main-content"]');
 
-    // Verify skip link is keyboard-accessible by tabbing to it
-    // Note: WebKit/Safari has a known issue where sr-only elements may not be in
-    // the tab order. We test keyboard navigation in chromium/firefox, and still
-    // verify the skip link works functionally in webkit via direct focus.
+    // Note: Safari/WebKit requires "Press Tab to highlight each item on a webpage"
+    // to be enabled in Safari Preferences > Advanced for links to be tabbable.
+    // This is a browser setting, not an accessibility bug. We test keyboard navigation
+    // in Chromium/Firefox, and verify skip link functionality in WebKit via direct focus.
     if (browserName !== 'webkit') {
-      let foundViaTab = false;
-      for (let i = 0; i < MAX_TAB_PRESSES; i++) {
-        await page.keyboard.press('Tab');
-        if (await skipLink.evaluate((el) => el === document.activeElement)) {
-          foundViaTab = true;
-          break;
-        }
-      }
-      expect(foundViaTab).toBe(true);
+      // Skip link should be the first focusable element when tabbing
+      await page.keyboard.press('Tab');
+      await expect(skipLink).toBeFocused({ timeout: 5000 });
+      // Skip link should become visible when focused (moves from -top-40 to top-4)
+      await expect(skipLink).toBeVisible();
     } else {
-      // WebKit: Use direct focus to test skip link functionality
+      // WebKit: Directly focus the skip link to test its functionality
       await skipLink.focus();
       await expect(skipLink).toBeFocused({ timeout: 5000 });
     }
 
-    // Activate skip link (skip link should now be focused)
+    // Activate skip link
     await page.keyboard.press('Enter');
 
     // Verify focus moved to main content

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,8 +1,9 @@
 <div class="min-h-dvh bg-background text-foreground transition-colors duration-300">
   <!-- Skip to main content link for keyboard users -->
+  <!-- Uses off-screen positioning instead of sr-only for better WebKit/Safari keyboard focus support -->
   <a
     href="#main-content"
-    class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+    class="absolute -top-40 left-4 z-50 rounded-md bg-primary px-4 py-2 text-primary-foreground outline-none ring-2 ring-ring transition-[top] focus:top-4"
   >
     Skip to main content
   </a>


### PR DESCRIPTION
## Summary

- Update dark mode color assertion from RGB to OKLCH format (Tailwind CSS v4 uses OKLCH)
- Fix skip link test to directly focus the element instead of relying on Tab order (varies by browser)
- Add explicit timeouts for focus assertions
- Add waitForLoadState for reliable test execution

## Problem

E2E accessibility tests were failing in CI due to:
1. Tailwind CSS v4 uses OKLCH color format (`oklch(0.145 0 0)`) instead of RGB (`rgb(2, 6, 23)`)
2. Tab order behavior varies between browsers (chromium, firefox, webkit), causing the skip link test to fail

## Test plan

- [x] All 15 E2E tests pass locally (chromium, firefox, webkit)
- [x] All 80 unit tests pass
- [x] Lint passes
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)