### PR TITLE
create-example-file-task

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "format:check": "prettier --check .",
     "e2e": "ng e2e",
     "test:a11y": "npx playwright test e2e/accessibility.spec.ts --project=chromium",
-    "prepare": "husky"
+    "prepare": "husky",
+    "create:example": "node scripts/create-example.mjs"
   },
   "prettier": {
     "printWidth": 100,

--- a/scripts/create-example.mjs
+++ b/scripts/create-example.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+/**
+ * Creates an example output file in the project root.
+ * This script is idempotent - safe to run multiple times.
+ */
+
+import { writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '..');
+const outputPath = resolve(projectRoot, 'example-output.txt');
+
+const content = `Example output file
+Generated at: ${new Date().toISOString()}
+`;
+
+writeFileSync(outputPath, content, 'utf-8');
+console.log(`Successfully created: ${outputPath}`);


### PR DESCRIPTION
Create a simple npm script that generates an example file without running any tests. This is a minimal task to demonstrate file creation via an npm script.