### PR TITLE
fix: correct Trust Wallet detection to prevent false positives

### DIFF
--- a/docs/wallets.md
+++ b/docs/wallets.md
@@ -17,7 +17,7 @@ The app supports these connectors (see [`WalletConnectorId`](conceal-bridge-ux/s
 
 - **Injected wallets**
   - MetaMask (detected via `window.ethereum.isMetaMask`, see [`isConnectorAvailable()`](conceal-bridge-ux/src/app/core/evm-wallet.service.ts:77))
-  - Trust Wallet (detected via Trust flags OR “not MetaMask”, see [`isConnectorAvailable()`](conceal-bridge-ux/src/app/core/evm-wallet.service.ts:86))
+  - Trust Wallet (detected via `isTrust` or `isTrustWallet` flags, see [`isConnectorAvailable()`](conceal-bridge-ux/src/app/core/evm-wallet.service.ts:86))
 - **Binance Wallet**
   - detected via `window.BinanceChain` (see [`hasBinanceProvider`](conceal-bridge-ux/src/app/core/evm-wallet.service.ts:58) and [`#binanceProvider()`](conceal-bridge-ux/src/app/core/evm-wallet.service.ts:292))
 

--- a/src/app/core/evm-wallet.service.spec.ts
+++ b/src/app/core/evm-wallet.service.spec.ts
@@ -218,9 +218,9 @@ describe('EvmWalletService', () => {
       expect(service.isConnectorAvailable('trust')).toBe(true);
     });
 
-    it('should return true for trust when not MetaMask (fallback)', () => {
+    it('should return false for trust when provider has no Trust flags', () => {
       service = reconfigureAndInjectService(createMockProvider({ isMetaMask: false }));
-      expect(service.isConnectorAvailable('trust')).toBe(true);
+      expect(service.isConnectorAvailable('trust')).toBe(false);
     });
 
     it('should return false for binance when no BinanceChain', () => {

--- a/src/app/core/evm-wallet.service.ts
+++ b/src/app/core/evm-wallet.service.ts
@@ -600,13 +600,9 @@ export class EvmWalletService {
     }
 
     if (connector === 'trust' && !(injected.isTrust || injected.isTrustWallet)) {
-      // Trust on desktop is often injected without flags; prefer letting it work.
-      // Only hard-fail if it's clearly MetaMask-only.
-      if (injected.isMetaMask) {
-        throw new Error(
-          'Trust Wallet not detected. Please install Trust Wallet or choose another wallet.',
-        );
-      }
+      throw new Error(
+        'Trust Wallet not detected. Please install Trust Wallet or choose another wallet.',
+      );
     }
 
     return injected;

--- a/src/app/core/evm-wallet.service.ts
+++ b/src/app/core/evm-wallet.service.ts
@@ -169,9 +169,7 @@ export class EvmWalletService {
 
     if (connector === 'metamask') return !!injected.isMetaMask;
 
-    // Trust Wallet desktop extension may not always set flags; treat "not MetaMask" as acceptable.
-    if (connector === 'trust')
-      return !!(injected.isTrust || injected.isTrustWallet) || !injected.isMetaMask;
+    if (connector === 'trust') return !!(injected.isTrust || injected.isTrustWallet);
 
     return false;
   }


### PR DESCRIPTION
## Summary
- Fixed bug in `isConnectorAvailable('trust')` that incorrectly returned `true` for any non-MetaMask wallet
- The fallback `|| !injected.isMetaMask` caused false positives for Coinbase Wallet, Phantom, Rainbow, etc.
- Trust Wallet detection now correctly relies only on explicit `isTrust`/`isTrustWallet` flags

## Test plan
- [x] Unit tests updated and passing (712 tests)
- [x] Lint passes
- [ ] Manual test: With MetaMask only installed, Trust Wallet should show as unavailable
- [ ] Manual test: With Trust Wallet installed, Trust Wallet should show as available
- [ ] Manual test: With Coinbase Wallet (or other non-MetaMask wallet) installed, Trust Wallet should show as unavailable

🤖 Generated with [Claude Code](https://claude.ai/claude-code)